### PR TITLE
Task publisher abstraction

### DIFF
--- a/v1/client/client.go
+++ b/v1/client/client.go
@@ -3,9 +3,10 @@ package client
 import (
 	"context"
 
-	api "github.com/bww/go-apiclient/v1"
 	"github.com/bww/go-tasks/v1"
 	"github.com/bww/go-tasks/v1/transport"
+
+	api "github.com/bww/go-apiclient/v1"
 )
 
 var jsonContentType = api.WithHeader("Content-Type", "application/json")

--- a/v1/config.go
+++ b/v1/config.go
@@ -1,7 +1,24 @@
 package tasks
 
+import (
+	"net/url"
+	"strconv"
+)
+
 type PublishConfig struct {
 	StateSeq int64
+}
+
+func PublishConfigFromParams(params url.Values) (PublishConfig, error) {
+	var c PublishConfig
+	if v := params.Get("state_seq"); v != "" {
+		x, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return c, err
+		}
+		c.StateSeq = x
+	}
+	return c, nil
 }
 
 func (c PublishConfig) WithOptions(opts []PublishOption) PublishConfig {
@@ -11,7 +28,30 @@ func (c PublishConfig) WithOptions(opts []PublishOption) PublishConfig {
 	return c
 }
 
+func (c PublishConfig) Params() url.Values {
+	params := make(url.Values)
+	if c.StateSeq != 0 {
+		params.Set("state_seq", strconv.FormatInt(c.StateSeq, 10))
+	}
+	return params
+}
+
+func (c PublishConfig) Query() string {
+	params := c.Params()
+	if len(params) > 0 {
+		return "?" + params.Encode()
+	} else {
+		return ""
+	}
+}
+
 type PublishOption func(PublishConfig) PublishConfig
+
+func UseConfig(v PublishConfig) PublishOption {
+	return func(c PublishConfig) PublishConfig {
+		return v // replace config
+	}
+}
 
 func WithStateSeq(seq int64) PublishOption {
 	return func(c PublishConfig) PublishConfig {


### PR DESCRIPTION
This adds a `Publisher` interface which is conformed to by `tasks.Queue` and `client.Client`.